### PR TITLE
Rename `dependency` to `name`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,16 +10,16 @@
 4. A YAML file named `manifest.yml` that has the following entries. See [cloud-kickstart/manifest.yml](cloud-kickstart/manifest.yml).  The CLI parses the manifest files to generate a list of plugins to install.
     - `description` - A one sentence description of the functionality.
     - `dependencies` - A list of what users must have installed to run it. Each entry must have the following fields:
-      - `dependency` - The name of the dependency.
+      - `name` - The name of the dependency.
       - `version` - A minimum required version to use the plugin.
 
     Example:
     ```
     description: Use the CLI to print Hello World.
     dependencies:
-    - dependency: Go
+    - name: Go
       version: "1.19.6"
-    - dependency: jq
+    - name: jq
       version: "1.6"
     ```
     The first dependency must be the language in which the plugin is written. Currently, we support Go, Python, and Shell scripts. Subsequent dependencies may be other programs required by your plugin, such as the [jq command line tool](https://jqlang.github.io/jq/).

--- a/confluent-api_key-purge/manifest.yml
+++ b/confluent-api_key-purge/manifest.yml
@@ -1,4 +1,4 @@
 description: Deletes API keys for the current user, specified environment, or service account
 dependencies:
-- dependency: Python
+- name: Python
   version: "3"

--- a/confluent-cloud_kickstart/manifest.yml
+++ b/confluent-cloud_kickstart/manifest.yml
@@ -1,4 +1,4 @@
 description: Creates a cluster, enables schema-registry, generates API keys, and outputs a client config file
 dependencies:
-- dependency: Python
+- name: Python
   version: "3"

--- a/confluent-login-headless_sso/manifest.yml
+++ b/confluent-login-headless_sso/manifest.yml
@@ -1,4 +1,4 @@
 description: Use a headless browser to automatically authenticate to Confluent Cloud with SSO.
 dependencies:
-- dependency: Go
+- name: Go
   version: "1.20"

--- a/confluent-schema_registry-schema-purge/manifest.yml
+++ b/confluent-schema_registry-schema-purge/manifest.yml
@@ -1,4 +1,4 @@
 description: Performs a hard delete on all schemas
 dependencies:
-  - dependency: Python
+  - name: Python
     version: "3"


### PR DESCRIPTION
Based on feedback from https://github.com/confluentinc/cli/pull/2014#discussion_r1258716631

The list of dependencies is already called `dependencies`, so it's more clear if each entry's first field is `name` instead of `dependency`.