### PR TITLE
Fix typo in `confluent-schema_registry-schema-purge`

### DIFF
--- a/confluent-schema_registry-schema-purge/confluent-schema_registry-schema-purge.py
+++ b/confluent-schema_registry-schema-purge/confluent-schema_registry-schema-purge.py
@@ -67,7 +67,7 @@ if args.env is not None:
     delete_schema_cmd.append(args.env)
 if args.subject_prefix is not None:
     list_schema_cmd.append('--subject-prefix')
-    list_schema_cmd.append(args.sa)
+    list_schema_cmd.append(args.subject_prefix)
 if args.api_key is None and args.api_secret is None:
     with open(args.secrets_file) as json_file:
         creds_json = json.load(json_file)


### PR DESCRIPTION
The python script contains a typo: `args.sa` should be `args.subject_prefix`.

Tested manually.
Without fix:
```
confluent schema-registry schema purge --api-key <key> --api-secret <secret> --subject-prefix json-test
Traceback (most recent call last):
  File "/Users/sgagniere/.confluent/plugins/confluent-schema_registry-schema-purge.py", line 70, in <module>
    list_schema_cmd.append(args.sa)
                           ^^^^^^^
AttributeError: 'Namespace' object has no attribute 'sa'
```
With fix:
```
confluent schema-registry schema purge --api-key <key> --api-secret <secret> --subject-prefix json-test
Found schema json-test-value at version 1
Found schema json-test-value at version 2
Are you sure you want to delete all schemas? y|n  n
Quitting and leaving all schemas in-place
```