### PR TITLE
fix: set active environment in Flink quickstart if provided

### DIFF
--- a/confluent-flink-quickstart/confluent-flink-quickstart.py
+++ b/confluent-flink-quickstart/confluent-flink-quickstart.py
@@ -154,10 +154,15 @@ parser.add_argument("--debug", action='store_true',
 args = parser.parse_args()
 debug = args.debug
 flink_region = args.region
+environment = args.environment
 
 table_format = "{:<45} {:<45} {:<45}"
 flink_plugin_start_time = datetime.datetime.now()
 max_wait_seconds = 300
+
+if environment is not None:
+    print(f'Setting the active environment to {environment}')
+    cli(["confluent", "environment", "use", environment], capture_output=False)
 
 print("Searching for existing databases (Kafka clusters)")
 cluster_list = cli(["confluent", "kafka", "cluster", "list",


### PR DESCRIPTION
This fixes an issue where resources get spun up in the active
 environment regardless of the --environment argument.