### PR TITLE
add wait / retry around Schema Registry in kickstart plugin

### DIFF
--- a/confluent-cloud_kickstart/README.md
+++ b/confluent-cloud_kickstart/README.md
@@ -1,18 +1,17 @@
 ### [confluent cloud-kickstart](confluent-cloud_kickstart.py)
-  - Creates a cluster with the preferred cloud provider and region
-  - Generates API key and secret for cluster access 
-  - Enables Schema Registry
+  - Creates a Kafka cluster in the preferred cloud provider and region
+  - Generates API key and secret for Kafka cluster access 
   - Sets the new API key as the active one for the cluster
   - Generates API key and secret for Schema Registry access
-  - Writes API key and secret for cluster and SR to files, writes client config to file
+  - Writes API key and secret for cluster and SR to files, writes client config to file or stdout
   - TODO
     - Support creating environment and service account
 #### Requirements
   - Python 3 (3.10.9 used for this plugin)  `brew install python3`
-  - [Confluent CLI v3.0.0](https://docs.confluent.io/confluent-cli/current/install.html)
+  - [Confluent CLI v4.0.0](https://docs.confluent.io/confluent-cli/current/install.html)
 #### Usage
 ```text
-usage: confluent cloud-kickstart [-h] --name NAME [--env ENV] [--cloud {aws,azure,gcp}] [--region REGION] [--geo {apac,eu,us}]
+usage: confluent cloud-kickstart [-h] --name NAME [--env ENV] [--cloud {aws,azure,gcp}] [--region REGION] [--output-format {properties,stdout}]
 [--client {clojure,cpp,csharp,go,groovy,java,kotlin,ktor,nodejs,python,restapi,ruby,rust,scala,springboot}] [--debug {y,n}] [--dir DIR]
 
 Creates a Kafka cluster with API keys, Schema Registry with API keys and a client config properties file. This plugin assumes confluent CLI v3.0.0 or greater
@@ -24,9 +23,12 @@ options:
   --cloud {aws,azure,gcp}
                         Cloud Provider, Defaults to aws
   --region REGION       Cloud region e.g us-west-2 (aws), westus (azure), us-west1 (gcp) Defaults to us-west-2
-  --geo {apac,eu,us}    Cloud geographical region Defaults to us
+  --output {properties,stdout}
+                        Whether to write client properties to a properties file or stdout
   --client {clojure,cpp,csharp,go,groovy,java,kotlin,ktor,nodejs,python,restapi,ruby,rust,scala,springboot}
-                        Properties file used by client (default java)
+                        Properties file used by client (default java). Only applies if `--output` argument is 
+                        `properties`.
   --debug               Prints the results of every command, defaults to n
-  --dir DIR             Directory to save credentials and client configs, defaults to download directory
+  --dir DIR             Directory to save credentials and client configs, defaults to download directory. Only applies
+                        if `--output` argument is `properties`.
 ```

--- a/confluent-cloud_kickstart/manifest.yml
+++ b/confluent-cloud_kickstart/manifest.yml
@@ -1,4 +1,4 @@
-description: Creates a cluster, enables schema-registry, generates API keys, and outputs a client config file
+description: Creates a Kafka cluster, generates Kafka and Schema Registry API keys, and outputs a client config file
 dependencies:
 - name: Python
   version: "3"


### PR DESCRIPTION
Because SR becomes available asynchronously, describing Schema Registry (to generate an API key) can hit a 401 error and then the plugin bails if we don't wait and retry.